### PR TITLE
Update CheckFileHash.java

### DIFF
--- a/src/main/java/com/lazerycode/selenium/filedownloader/CheckFileHash.java
+++ b/src/main/java/com/lazerycode/selenium/filedownloader/CheckFileHash.java
@@ -17,6 +17,7 @@
 package com.lazerycode.selenium.filedownloader;
 
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 
 import java.io.File;
@@ -69,11 +70,11 @@ public class CheckFileHash {
 
         switch (this.typeOfOfHash) {
             case MD5:
-                actualFileHash = DigestUtils.md5Hex(new FileInputStream(this.fileToCheck));
+                actualFileHash = DigestUtils.md5Hex(IOUtils.toByteArray(new FileInputStream(this.fileToCheck)));
                 if (this.expectedFileHash.equals(actualFileHash)) isHashValid = true;
                 break;
             case SHA1:
-                actualFileHash = DigestUtils.shaHex(new FileInputStream(this.fileToCheck));
+                actualFileHash = DigestUtils.shaHex(IOUtils.toByteArray(new FileInputStream(this.fileToCheck)));
                 if (this.expectedFileHash.equals(actualFileHash)) isHashValid = true;
                 break;
         }


### PR DESCRIPTION
As raw FileInputStream can`t be cast to shaHex/md5Hex directly(give error), use wrap IOUtils, as described in https://dalanzg.github.io/tips-tutorials/java/2016/03/22/how-to-get-md5-checksum-for-a-file-in-java/
Thanks for great job.